### PR TITLE
Fix PHP 7.1 errors

### DIFF
--- a/AllInOneMinify.module
+++ b/AllInOneMinify.module
@@ -710,7 +710,7 @@ class AllInOneMinify extends WireData implements Module, ConfigurableModule {
         // Calculate timestamp of all files
         // ------------------------------------------------------------------------
         foreach ($files as $file) {
-            $_timestamp = ($_timestamp + $file['last_modified']);
+            $_timestamp = ((int)$_timestamp + $file['last_modified']);
         }
 
         // ------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the PHP 7.1 errors as explained by @adrian at https://processwire.com/talk/topic/5630-module-aiom-all-in-one-minify-for-css-less-js-and-html/?do=findComment&comment=128784.

A non well formed numeric value encountered on line 713 notice